### PR TITLE
Prioritize subject over TopicArn

### DIFF
--- a/src/Queue/Jobs/SqsSnsJob.php
+++ b/src/Queue/Jobs/SqsSnsJob.php
@@ -47,7 +47,7 @@ class SqsSnsJob extends SqsJob
         $commandName = null;
 
         // available parameters to route your jobs by
-        $possibleRouteParams = ['TopicArn', 'Subject'];
+        $possibleRouteParams = ['Subject', 'TopicArn'];
 
         foreach ($possibleRouteParams as $param) {
             if (isset($body[$param]) && array_key_exists($body[$param], $routes)) {


### PR DESCRIPTION
So we can create a "default" handler for the jobs (mostly to throw away the jobs) using the topicArn in the config