### PR TITLE
Add displayName to job body

### DIFF
--- a/src/Queue/Jobs/SqsSnsJob.php
+++ b/src/Queue/Jobs/SqsSnsJob.php
@@ -68,6 +68,7 @@ class SqsSnsJob extends SqsJob
             // the job is reconstructed.
 
             $job['Body'] = json_encode([
+                'displayName' => $commandName,
                 'job' => CallQueuedHandler::class . '@call',
                 'data' => compact('commandName', 'command'),
             ]);


### PR DESCRIPTION
Simple change to `SqsSnsJob` adds `displayName` to the body, which properly shows what job is running in the console.

**Before:**
![image](https://user-images.githubusercontent.com/489912/73128023-5d32cf80-3f86-11ea-90d3-faad787a5759.png)

**After:**
![image](https://user-images.githubusercontent.com/489912/73128024-6328b080-3f86-11ea-92d6-cf15e5845cd0.png)
