### PR TITLE
Update SqsSnsJob.php

### DIFF
--- a/src/Queue/Jobs/SqsSnsJob.php
+++ b/src/Queue/Jobs/SqsSnsJob.php
@@ -89,7 +89,7 @@ class SqsSnsJob extends SqsJob
         $payload = json_decode($body['Message'], true);
 
         $data = [
-            'subject' => $body['Subject'],
+            'subject' => (isset($body['Subject'])) ? $body['Subject'] : '',
             'payload' => $payload
         ];
 


### PR DESCRIPTION
In the event that the "Subject" is not defined within the body, to avoid errors substitute an empty string. For example an SNS message created by an MQTT device.